### PR TITLE
add schedule for main workflow; re-add drat backup

### DIFF
--- a/workflows/pull-request.yaml
+++ b/workflows/pull-request.yaml
@@ -35,6 +35,7 @@ jobs:
           install.packages('remotes')
           options(repos = c(
             "https://carpentries.r-universe.dev/", 
+            "https://carpentries.github.io/drat/",
             "https://cloud.r-project.org/"
           ))
           saveRDS(remotes::package_deps('sandpaper', dependencies = TRUE), 
@@ -58,6 +59,7 @@ jobs:
         run: |
           options(repos = c(
             "https://carpentries.r-universe.dev/", 
+            "https://carpentries.github.io/drat/",
             "https://cloud.r-project.org/"
           ))
           pkgs <- remotes::package_deps('sandpaper', dependencies = TRUE)

--- a/workflows/sandpaper-main.yaml
+++ b/workflows/sandpaper-main.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - master
+  schedule:
+    '0 0 * * 2'
 
 jobs:
   full-build:
@@ -26,6 +28,7 @@ jobs:
           install.packages('remotes')
           options(repos = c(
             "https://carpentries.r-universe.dev/", 
+            "https://carpentries.github.io/drat/",
             "https://cloud.r-project.org/"
           ))
           saveRDS(remotes::package_deps('sandpaper', dependencies = TRUE), 
@@ -49,6 +52,7 @@ jobs:
         run: |
           options(repos = c(
             "https://carpentries.r-universe.dev/", 
+            "https://carpentries.github.io/drat/",
             "https://cloud.r-project.org/"
           ))
           pkgs <- remotes::package_deps('sandpaper', dependencies = TRUE)
@@ -73,6 +77,11 @@ jobs:
             sessioninfo::package_info("sandpaper", dependencies = TRUE)
           }
         shell: Rscript {0}
+
+      - name: Reset site
+        if: ${{ github.event_name == "schedule" }}
+        run: |
+          Rscript -e 'sandpaper::reset_site()'
 
       - name: Deploy Site
         run: |

--- a/workflows/sandpaper-main.yaml
+++ b/workflows/sandpaper-main.yaml
@@ -7,7 +7,16 @@ on:
       - master
   schedule:
     '0 0 * * 2'
-
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Who triggered this build?'
+        required: true
+        default: 'Maintainer (via GitHub)'
+      reset:
+        description: 'Should the cached markdown files be reset?'
+        required: true
+        default: false
 jobs:
   full-build:
     name: "Build Full Site"
@@ -79,7 +88,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Reset site
-        if: ${{ github.event_name == "schedule" }}
+        if: ${{ github.event_name == "schedule" || (github.event_name == "workflow_dispatch" && github.event.input.reset)}}
         run: |
           Rscript -e 'sandpaper::reset_site()'
 

--- a/workflows/sandpaper-main.yaml
+++ b/workflows/sandpaper-main.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - master
   schedule:
-    '0 0 * * 2'
+    - cron: '0 0 * * 2'
   workflow_dispatch:
     inputs:
       name:
@@ -14,9 +14,9 @@ on:
         required: true
         default: 'Maintainer (via GitHub)'
       reset:
-        description: 'Should the cached markdown files be reset?'
+        description: 'Should the cached markdown files be reset? (true/false)'
         required: true
-        default: false
+        default: 'false'
 jobs:
   full-build:
     name: "Build Full Site"
@@ -88,7 +88,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Reset site
-        if: ${{ github.event_name == "schedule" || (github.event_name == "workflow_dispatch" && github.event.input.reset)}}
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.reset == 'true'}}
         run: |
           Rscript -e 'sandpaper::reset_site()'
 


### PR DESCRIPTION
One thing that has been needed is a workflow schedule for rebuilding the
site to incorporate changes from the infrastructure. Since we are still
interating over the process of creating the markdown files, we are
forcing it to start from scratch right now.